### PR TITLE
fix lme4::simulate.merMod compatibility

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -288,14 +288,17 @@ simulate.wbm <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
   object <- to_merMod(object)
   
   if (!is.na(re.form)) {
+    ## unused terms and type arguments throw warning
     simulate(object, nsim = nsim, seed = seed,
              newdata = newdata, newparams = newparams, re.form = re.form,
-             terms = NULL, type = type, allow.new.levels = allow.new.levels,
+             ## terms = NULL, type = type,
+             allow.new.levels = allow.new.levels,
              na.action = na.action, ...)
   } else {
     simulate(object, nsim = nsim, seed = seed,
              newdata = newdata, newparams = newparams, use.u = use.u,
-             terms = NULL, type = type, allow.new.levels = allow.new.levels,
+             ## terms = NULL, type = type,
+             allow.new.levels = allow.new.levels,
              na.action = na.action, ...)
   }
   


### PR DESCRIPTION
This seems to work (and hard to see what harm it could do since these arguments couldn't ever have done anything in the first place).  Don't know if you want to (1) throw away the comments (2) implement your own warning for unused arguments?