### PR TITLE
Use variable names rather than variable order when manipulating results from clubSandwich::coef_test().

### DIFF
--- a/R/asym.R
+++ b/R/asym.R
@@ -91,7 +91,7 @@ asym <- function(formula, data, id = NULL, wave = NULL, use.wave = FALSE,
                       data = data)
   coef_table <- as.data.frame(clubSandwich::coef_test(gls_mod, vcov = the_vcov,
                                         test = "naive-t", cluster = data[[id]]))
-  coef_table <- as.data.frame(coef_table)
+  coef_table <- as.data.frame(coef_table[c("beta","SE","tstat","p_t")])
   if ("tstat" %nin% names(coef_table)) { # old version of clubSandwich
     names(coef_table) <- c("estimate", "std.error", "p.value")
     coef_table["statistic"] <- coef_table$estimate / coef_table$std.error

--- a/R/diffs.R
+++ b/R/diffs.R
@@ -73,7 +73,7 @@ fdm <- function(formula, data, id = NULL, wave = NULL, use.wave = FALSE,
                       data = data)
   coef_table <- clubSandwich::coef_test(gls_mod, vcov = the_vcov,
                                         test = "naive-t", cluster = data[[id]])
-  coef_table <- as.data.frame(coef_table)
+  coef_table <- as.data.frame(coef_table[c("beta","SE","tstat","p_t")])
   if ("tstat" %nin% names(coef_table)) { # old version of clubSandwich
     names(coef_table) <- c("estimate", "std.error", "p.value")
     coef_table["statistic"] <- coef_table$estimate / coef_table$std.error


### PR DESCRIPTION
Hi Jacob,

A forthcoming release of clubSandwich makes some changes to the format of the output of `coef_test()` so that the results include the coefficient names in a variable rather than solely in the `row.names` attribute. This change creates a bug in `panelr` because `asym()` and `fdm()` call `coef_test()` and then manipulate the results based on variable order, so adding a new first variable garbles the coefficient tables produced by these models. I think it suffices to pull the variables you need based on their names rather than position, as I've done in this pull request. I'd be grateful if you could take a look.

Kind Regards,
James