### PR TITLE
Early convert to tibble before calling `distinct()`

### DIFF
--- a/R/reconstruct.R
+++ b/R/reconstruct.R
@@ -87,7 +87,9 @@ dplyr::filter
 #' @export
 #' @importFrom dplyr distinct
 distinct.panel_data <- function(.data, ..., .keep_all = FALSE) {
-  reconstruct(NextMethod(), .data)
+  out <- tibble::as_tibble(.data)
+  out <- dplyr::distinct(out, ..., .keep_all = .keep_all)
+  reconstruct(out, .data)
 }
 
 #' @export


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`distinct()` now uses our advertised extension point for column selection, `x[loc]` (see `?dplyr::dplyr_extending`), and checks that the number of columns returned by `[` is exactly equal to the number of columns specified by `loc`. This isn't true with the `[` method of panelr (the wave column is sticky), so `distinct()` will now error with something like:

```r
w <- panel_data(WageData, id = id, wave = t)

distinct(w, lwage)
#> ! Can't reconstruct data frame.
#> ✖ The `[` method for class
#>   <panel_data/grouped_df/tbl_df/tbl/data.frame> must return a
#>   data frame with 2 columns.
#> ℹ It returned a <panel_data/grouped_df/tbl_df/tbl/data.frame> of
#>   3 columns.
```

For maximum compatibility with dplyr, the best thing for us would be if `x[loc]` always followed the invariant mentioned above about the number of columns returned (meaning it would also fallback to returning a tibble if the panelr sticky columns aren't selected). `select()` would be the interface that would always keep the "sticky" columns.

If you don't want to do that, this PR just does an early conversion to tibble in your `distinct()` method before handing off to dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!